### PR TITLE
Add package description for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@reason-react-native/checkbox",
   "version": "0.5.0",
+  "description": "ReScript bindings for @react-native-community/react-native-checkbox.",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
For a better representation on npmjs and the future rescript-lang.org package index

Here is an example on how it looks like right now (defaulting to the less ideal README file):

![image](https://user-images.githubusercontent.com/1121889/98951907-20c36680-24fb-11eb-910e-4f81b4c78faf.png)

